### PR TITLE
Set default icons and restore mode for Gree switches

### DIFF
--- a/esphome/components/gree/gree.cpp
+++ b/esphome/components/gree/gree.cpp
@@ -1,5 +1,8 @@
 #include "gree.h"
 #include "esphome/components/remote_base/remote_base.h"
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
 
 namespace esphome {
 namespace gree {
@@ -16,13 +19,93 @@ void GreeClimate::set_model(Model model) {
   this->model_ = model;
 }
 
+#ifdef USE_SWITCH
+void GreeClimate::set_turbo_switch(switch_::Switch *sw) {
+  this->turbo_switch_ = sw;
+  this->turbo_switch_->publish_state(this->turbo_mode_);
+}
+
+void GreeClimate::set_light_switch(switch_::Switch *sw) {
+  this->light_switch_ = sw;
+  this->light_switch_->publish_state(this->light_mode_);
+}
+
+void GreeClimate::set_health_switch(switch_::Switch *sw) {
+  this->health_switch_ = sw;
+  this->health_switch_->publish_state(this->health_mode_);
+}
+
+void GreeClimate::set_xfan_switch(switch_::Switch *sw) {
+  this->xfan_switch_ = sw;
+  this->xfan_switch_->publish_state(this->xfan_mode_);
+}
+#endif
+
+void GreeClimate::set_turbo_mode(bool enabled) {
+  if (this->turbo_mode_ == enabled)
+    return;
+
+  this->turbo_mode_ = enabled;
+#ifdef USE_SWITCH
+  if (this->turbo_switch_ != nullptr) {
+    this->turbo_switch_->publish_state(enabled);
+  }
+#endif
+  this->transmit_state();
+}
+
+void GreeClimate::set_light_mode(bool enabled) {
+  if (this->light_mode_ == enabled)
+    return;
+
+  this->light_mode_ = enabled;
+#ifdef USE_SWITCH
+  if (this->light_switch_ != nullptr) {
+    this->light_switch_->publish_state(enabled);
+  }
+#endif
+  this->transmit_state();
+}
+
+void GreeClimate::set_health_mode(bool enabled) {
+  if (this->health_mode_ == enabled)
+    return;
+
+  this->health_mode_ = enabled;
+#ifdef USE_SWITCH
+  if (this->health_switch_ != nullptr) {
+    this->health_switch_->publish_state(enabled);
+  }
+#endif
+  this->transmit_state();
+}
+
+void GreeClimate::set_xfan_mode(bool enabled) {
+  if (this->xfan_mode_ == enabled)
+    return;
+
+  this->xfan_mode_ = enabled;
+#ifdef USE_SWITCH
+  if (this->xfan_switch_ != nullptr) {
+    this->xfan_switch_->publish_state(enabled);
+  }
+#endif
+  this->transmit_state();
+}
+
 void GreeClimate::transmit_state() {
   uint8_t remote_state[8] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00};
 
   remote_state[0] = this->fan_speed_() | this->operation_mode_();
   remote_state[1] = this->temperature_();
 
-  if (this->model_ == GREE_YAN || this->model_ == GREE_YX1FF || this->model_ == GREE_YAG) {
+  if (this->model_ == GREE_YAN) {
+    remote_state[2] = 0x20;  // bits 0..3 always 0000, bits 4..7 TURBO, LIGHT, HEALTH, X-FAN
+    remote_state[3] = 0x50;  // bits 4..7 always 0101
+    remote_state[4] = this->vertical_swing_();
+  }
+
+  if (this->model_ == GREE_YX1FF || this->model_ == GREE_YAG) {
     remote_state[2] = 0x60;
     remote_state[3] = 0x50;
     remote_state[4] = this->vertical_swing_();
@@ -41,7 +124,7 @@ void GreeClimate::transmit_state() {
   }
 
   if (this->model_ == GREE_YAA || this->model_ == GREE_YAC || this->model_ == GREE_YAC1FB9) {
-    remote_state[2] = 0x20;  // bits 0..3 always 0000, bits 4..7 TURBO,LIGHT,HEALTH,X-FAN
+    remote_state[2] = 0x20;  // bits 0..3 always 0000, bits 4..7 TURBO, LIGHT, HEALTH, X-FAN
     remote_state[3] = 0x50;  // bits 4..7 always 0101
     remote_state[6] = 0x20;  // YAA1FB, FAA1FB1, YB1F2 bits 4..7 always 0010
 
@@ -49,6 +132,32 @@ void GreeClimate::transmit_state() {
       remote_state[0] |= (1 << 6);  // Enable swing by setting bit 6
     } else if (this->vertical_swing_() != GREE_VDIR_AUTO) {
       remote_state[5] = this->vertical_swing_();
+    }
+  }
+
+  if (this->model_ == GREE_YAN || this->model_ == GREE_YAA || this->model_ == GREE_YAC || this->model_ == GREE_YAC1FB9) {
+    if (this->turbo_mode_) {
+      remote_state[2] |= (1 << 4);  // Set bit 4 (TURBO ON)
+    } else {
+      remote_state[2] &= ~(1 << 4);  // Clear bit 4 (TURBO OFF)
+    }
+
+    if (this->light_mode_) {
+      remote_state[2] |= (1 << 5);  // Set bit 5 (LIGHT ON)
+    } else {
+      remote_state[2] &= ~(1 << 5);  // Clear bit 5 (LIGHT OFF)
+    }
+
+    if (this->health_mode_) {
+      remote_state[2] |= (1 << 6);  // Set bit 6 (HEALTH ON)
+    } else {
+      remote_state[2] &= ~(1 << 6);  // Clear bit 6 (HEALTH OFF)
+    }
+
+    if (this->xfan_mode_) {
+      remote_state[2] |= (1 << 7);  // Set bit 7 (X-FAN ON)
+    } else {
+      remote_state[2] &= ~(1 << 7);  // Clear bit 7 (X-FAN OFF)
     }
   }
 

--- a/esphome/components/gree/gree.h
+++ b/esphome/components/gree/gree.h
@@ -3,6 +3,11 @@
 #include "esphome/components/climate_ir/climate_ir.h"
 
 namespace esphome {
+#ifdef USE_SWITCH
+namespace switch_ {
+class Switch;
+}
+#endif
 namespace gree {
 
 // Values for GREE IR Controllers
@@ -90,6 +95,16 @@ class GreeClimate : public climate_ir::ClimateIR {
                                climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH}) {}
 
   void set_model(Model model);
+#ifdef USE_SWITCH
+  void set_turbo_switch(switch_::Switch *sw);
+  void set_light_switch(switch_::Switch *sw);
+  void set_health_switch(switch_::Switch *sw);
+  void set_xfan_switch(switch_::Switch *sw);
+#endif
+  void set_turbo_mode(bool enabled);
+  void set_light_mode(bool enabled);
+  void set_health_mode(bool enabled);
+  void set_xfan_mode(bool enabled);
 
  protected:
   // Transmit via IR the state of this climate controller.
@@ -103,6 +118,16 @@ class GreeClimate : public climate_ir::ClimateIR {
   uint8_t preset_();
 
   Model model_{};
+#ifdef USE_SWITCH
+  switch_::Switch *turbo_switch_{nullptr};
+  switch_::Switch *light_switch_{nullptr};
+  switch_::Switch *health_switch_{nullptr};
+  switch_::Switch *xfan_switch_{nullptr};
+#endif
+  bool turbo_mode_{false};
+  bool light_mode_{false};
+  bool health_mode_{false};
+  bool xfan_mode_{false};
 };
 
 }  // namespace gree

--- a/esphome/components/gree/switch/__init__.py
+++ b/esphome/components/gree/switch/__init__.py
@@ -1,0 +1,95 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import CONF_HEALTH, CONF_ID
+import esphome.final_validate as fv
+
+from ..climate import CONF_MODEL, GreeClimate, Model
+from .. import gree_ns
+
+CODEOWNERS = ["@orestismers"]
+DEPENDENCIES = ["gree"]
+
+GreeTurboSwitch = gree_ns.class_("GreeTurboSwitch", switch.Switch)
+GreeLightSwitch = gree_ns.class_("GreeLightSwitch", switch.Switch)
+GreeHealthSwitch = gree_ns.class_("GreeHealthSwitch", switch.Switch)
+GreeXfanSwitch = gree_ns.class_("GreeXfanSwitch", switch.Switch)
+
+CONF_TURBO = "turbo"
+CONF_LIGHT = "light"
+CONF_HEALTH_MODE = CONF_HEALTH
+CONF_XFAN = "xfan"
+
+SUPPORTED_MODELS = {
+    Model.GREE_YAN,
+    Model.GREE_YAA,
+    Model.GREE_YAC,
+    Model.GREE_YAC1FB9,
+}
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(GreeClimate),
+        cv.Optional(CONF_TURBO): switch.switch_schema(
+            GreeTurboSwitch,
+            icon="mdi:car-turbocharger",
+            default_restore_mode="RESTORE_DEFAULT_OFF",
+        ),
+        cv.Optional(CONF_LIGHT): switch.switch_schema(
+            GreeLightSwitch,
+            icon="mdi:led-outline",
+            default_restore_mode="RESTORE_DEFAULT_OFF",
+        ),
+        cv.Optional(CONF_HEALTH_MODE): switch.switch_schema(
+            GreeHealthSwitch,
+            icon="mdi:tree-outline",
+            default_restore_mode="RESTORE_DEFAULT_OFF",
+        ),
+        cv.Optional(CONF_XFAN): switch.switch_schema(
+            GreeXfanSwitch,
+            icon="mdi:wall-sconce-flat",
+            default_restore_mode="RESTORE_DEFAULT_OFF",
+        ),
+    }
+)
+
+
+def _validate_model(config):
+    full_config = fv.full_config.get()
+    climate_path = full_config.get_path_for_id(config[CONF_ID])[:-1]
+    climate_conf = full_config.get_config_for_path(climate_path)
+    if climate_conf is None:
+        raise cv.Invalid("Gree climate reference is invalid")
+    model = climate_conf.get(CONF_MODEL)
+    if model is None:
+        raise cv.Invalid("Gree climate model is not configured")
+
+    if model not in SUPPORTED_MODELS:
+        raise cv.Invalid("Gree switches are only supported for the yan, yaa, yac and yac1fb9 models")
+
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _validate_model
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ID])
+
+    if turbo_conf := config.get(CONF_TURBO):
+        turbo_switch = await switch.new_switch(turbo_conf)
+        await cg.register_parented(turbo_switch, parent)
+        cg.add(parent.set_turbo_switch(turbo_switch))
+    if light_conf := config.get(CONF_LIGHT):
+        light_switch = await switch.new_switch(light_conf)
+        await cg.register_parented(light_switch, parent)
+        cg.add(parent.set_light_switch(light_switch))
+    if health_conf := config.get(CONF_HEALTH_MODE):
+        health_switch = await switch.new_switch(health_conf)
+        await cg.register_parented(health_switch, parent)
+        cg.add(parent.set_health_switch(health_switch))
+    if xfan_conf := config.get(CONF_XFAN):
+        xfan_switch = await switch.new_switch(xfan_conf)
+        await cg.register_parented(xfan_switch, parent)
+        cg.add(parent.set_xfan_switch(xfan_switch))
+

--- a/esphome/components/gree/switch/gree_switch.cpp
+++ b/esphome/components/gree/switch/gree_switch.cpp
@@ -1,0 +1,23 @@
+#include "gree_switch.h"
+
+namespace esphome {
+namespace gree {
+
+void GreeTurboSwitch::write_state(bool state) {
+  this->parent_->set_turbo_mode(state);
+}
+
+void GreeLightSwitch::write_state(bool state) {
+  this->parent_->set_light_mode(state);
+}
+
+void GreeHealthSwitch::write_state(bool state) {
+  this->parent_->set_health_mode(state);
+}
+
+void GreeXfanSwitch::write_state(bool state) {
+  this->parent_->set_xfan_mode(state);
+}
+
+}  // namespace gree
+}  // namespace esphome

--- a/esphome/components/gree/switch/gree_switch.h
+++ b/esphome/components/gree/switch/gree_switch.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/gree/gree.h"
+
+namespace esphome {
+namespace gree {
+
+class GreeTurboSwitch : public switch_::Switch, public Parented<GreeClimate> {
+ public:
+  void write_state(bool state) override;
+};
+
+class GreeLightSwitch : public switch_::Switch, public Parented<GreeClimate> {
+ public:
+  void write_state(bool state) override;
+};
+
+class GreeHealthSwitch : public switch_::Switch, public Parented<GreeClimate> {
+ public:
+  void write_state(bool state) override;
+};
+
+class GreeXfanSwitch : public switch_::Switch, public Parented<GreeClimate> {
+ public:
+  void write_state(bool state) override;
+};
+
+}  // namespace gree
+}  // namespace esphome


### PR DESCRIPTION
## Summary
- assign default Material Design icons for Gree turbo, light, health, and X-FAN switches
- default the Gree switch restore mode to RESTORE_DEFAULT_OFF for consistent startup behavior

## Testing
- python -m compileall esphome/components/gree


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69296a52b284832788f483ca8817f53e)