### PR TITLE
Remove default esp32 BLE tracker ID from bthome mithermometer

### DIFF
--- a/esphome/components/bthome_mithermometer/__init__.py
+++ b/esphome/components/bthome_mithermometer/__init__.py
@@ -7,13 +7,11 @@ CODEOWNERS = ["@nagyrobi"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 AUTO_LOAD = ["esp32_ble_tracker"]
 
-DEFAULT_ESP32_BLE_ID = "esp32_ble_tracker_esp32bletracker_id"
-
 BLE_DEVICE_SCHEMA = cv.Schema(
     {
-        cv.Optional(
-            esp32_ble_tracker.CONF_ESP32_BLE_ID, default=DEFAULT_ESP32_BLE_ID
-        ): cv.use_id(esp32_ble_tracker.ESP32BLETracker),
+        cv.Optional(esp32_ble_tracker.CONF_ESP32_BLE_ID): cv.use_id(
+            esp32_ble_tracker.ESP32BLETracker
+        ),
     }
 )
 
@@ -41,7 +39,5 @@ def bthome_mithermometer_base_schema(extra_schema=None):
 
 async def setup_bthome_mithermometer(var, config):
     await cg.register_component(var, config)
-    tracker_config = dict(config)
-    tracker_config.setdefault(esp32_ble_tracker.CONF_ESP32_BLE_ID, DEFAULT_ESP32_BLE_ID)
-    await esp32_ble_tracker.register_ble_device(var, tracker_config)
+    await esp32_ble_tracker.register_ble_device(var, config)
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))


### PR DESCRIPTION
## Summary
- remove the hardcoded esp32 BLE tracker default ID from the bthome mithermometer component
- simplify BLE device registration by passing the component configuration directly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae57a6c7883278d9d34d055e5df39)