### PR TITLE
Fix default BLE tracker for bthome_mithermometer

### DIFF
--- a/esphome/components/bthome_mithermometer/__init__.py
+++ b/esphome/components/bthome_mithermometer/__init__.py
@@ -7,13 +7,7 @@ CODEOWNERS = ["@nagyrobi"]
 DEPENDENCIES = ["esp32_ble_tracker"]
 AUTO_LOAD = ["esp32_ble_tracker"]
 
-BLE_DEVICE_SCHEMA = cv.Schema(
-    {
-        cv.Optional(esp32_ble_tracker.CONF_ESP32_BLE_ID): cv.use_id(
-            esp32_ble_tracker.ESP32BLETracker
-        ),
-    }
-)
+BLE_DEVICE_SCHEMA = esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA
 
 bthome_mithermometer_ns = cg.esphome_ns.namespace("bthome_mithermometer")
 BTHomeMiThermometer = bthome_mithermometer_ns.class_(


### PR DESCRIPTION
## Summary
- reuse the shared ESP_BLE_DEVICE_SCHEMA so the BLE tracker id is always present for BTHome Mi Thermometer sensors

## Testing
- python -m esphome compile /tmp/bthome_test.yaml *(fails: SSL certificate verification error while downloading esp-idf)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ae75d53e483278dc183d508e272e8)