### PR TITLE
Update CODEOWNERS for bthome_mithermometer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -91,7 +91,7 @@ esphome/components/bmp3xx_spi/* @latonita
 esphome/components/bmp581/* @kahrendt
 esphome/components/bp1658cj/* @Cossid
 esphome/components/bp5758d/* @Cossid
-esphome/components/bthome_mithermometer/* @nagyrobi
+esphome/components/bthome_mithermometer/* @esphome/core @nagyrobi
 esphome/components/button/* @esphome/core
 esphome/components/bytebuffer/* @clydebarrow
 esphome/components/camera/* @bdraco @DT-art1


### PR DESCRIPTION
## Summary
- add esphome/core as codeowners for the bthome_mithermometer component

## Testing
- PYTHONPATH=. python script/build_codeowners.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bdfbff2908327bd64cbc730fc2aed)