### PR TITLE
Add host shell command helper

### DIFF
--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 
-from .const import KEY_HOST, host_ns
+from .const import KEY_HOST
 
 # force import gpio to register pin schema
 from .gpio import host_pin_to_code  # noqa
@@ -48,5 +48,3 @@ async def to_code(config):
     cg.add_platformio_option("platform", "platformio/native")
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")
-    cg.add_global(cg.RawStatement('#include "esphome/components/host/shell_command.h"'))
-    cg.add_global(host_ns.using)

--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 
-from .const import KEY_HOST
+from .const import KEY_HOST, host_ns
 
 # force import gpio to register pin schema
 from .gpio import host_pin_to_code  # noqa
@@ -48,3 +48,5 @@ async def to_code(config):
     cg.add_platformio_option("platform", "platformio/native")
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")
+    cg.add_global(cg.RawStatement('#include "esphome/components/host/shell_command.h"'))
+    cg.add_global(host_ns.using)

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -42,8 +42,7 @@ static bool create_pipe(int fds[2]) {
 
 static std::map<std::string, std::string> current_environment() {
   std::map<std::string, std::string> env_map;
-  extern char **environ;
-  for (char **env = environ; env != nullptr && *env != nullptr; ++env) {
+  for (char **env = ::environ; env != nullptr && *env != nullptr; ++env) {
     const std::string entry(*env);
     auto separator = entry.find('=');
     if (separator == std::string::npos) {

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -1,0 +1,188 @@
+#ifdef USE_HOST
+
+#if !(defined(__linux__) || defined(__APPLE__))
+#error This Host shell command implementation is not supported on this host OS
+#endif
+
+#include "shell_command.h"
+#include "esphome/core/log.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <csignal>
+#include <fcntl.h>
+#include <map>
+#include <string>
+#include <sys/select.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <vector>
+#include <unistd.h>
+
+namespace esphome {
+namespace host {
+
+static const char *const TAG = "host.shell";
+
+static bool create_pipe(int fds[2]) {
+#ifdef O_CLOEXEC
+  if (pipe2(fds, O_CLOEXEC) == 0) {
+    return true;
+  }
+#endif
+  if (pipe(fds) != 0) {
+    return false;
+  }
+  // Ensure the descriptors are close-on-exec even if pipe2 is unavailable.
+  fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+  fcntl(fds[1], F_SETFD, FD_CLOEXEC);
+  return true;
+}
+
+static std::map<std::string, std::string> current_environment() {
+  std::map<std::string, std::string> env_map;
+  extern char **environ;
+  for (char **env = environ; env != nullptr && *env != nullptr; ++env) {
+    const std::string entry(*env);
+    auto separator = entry.find('=');
+    if (separator == std::string::npos) {
+      continue;
+    }
+    env_map[entry.substr(0, separator)] = entry.substr(separator + 1);
+  }
+  return env_map;
+}
+
+ShellCommandResult execute_shell_command(const std::string &command, const ShellCommandOptions &options) {
+  ShellCommandResult result{};
+
+  int stdout_pipe[2];
+  int stderr_pipe[2];
+  if (!create_pipe(stdout_pipe) || !create_pipe(stderr_pipe)) {
+    ESP_LOGE(TAG, "Creating pipes failed: errno=%d", errno);
+    return result;
+  }
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    ESP_LOGE(TAG, "Fork failed: errno=%d", errno);
+    close(stdout_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[0]);
+    close(stderr_pipe[1]);
+    return result;
+  }
+
+  if (pid == 0) {
+    std::string shell = options.shell.empty() ? "/bin/sh" : options.shell;
+
+    auto env_map = current_environment();
+    for (const auto &kv : options.environment) {
+      env_map[kv.first] = kv.second;
+    }
+
+    std::vector<std::string> env_strings;
+    env_strings.reserve(env_map.size());
+    for (const auto &kv : env_map) {
+      env_strings.push_back(kv.first + "=" + kv.second);
+    }
+
+    std::vector<char *> envp;
+    envp.reserve(env_strings.size() + 1);
+    for (auto &entry : env_strings) {
+      envp.push_back(entry.data());
+    }
+    envp.push_back(nullptr);
+
+    if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 || dup2(stderr_pipe[1], STDERR_FILENO) == -1) {
+      _exit(127);
+    }
+    close(stdout_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[0]);
+    close(stderr_pipe[1]);
+    const char *argv[] = {shell.c_str(), "-c", command.c_str(), nullptr};
+    execve(shell.c_str(), const_cast<char *const *>(argv), envp.data());
+    _exit(127);
+  }
+
+  close(stdout_pipe[1]);
+  close(stderr_pipe[1]);
+
+  bool stdout_open = true;
+  bool stderr_open = true;
+  std::array<char, 4096> buffer{};
+
+  while (stdout_open || stderr_open) {
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    int max_fd = -1;
+    if (stdout_open) {
+      FD_SET(stdout_pipe[0], &read_fds);
+      max_fd = std::max(max_fd, stdout_pipe[0]);
+    }
+    if (stderr_open) {
+      FD_SET(stderr_pipe[0], &read_fds);
+      max_fd = std::max(max_fd, stderr_pipe[0]);
+    }
+
+    int ready = select(max_fd + 1, &read_fds, nullptr, nullptr, nullptr);
+    if (ready == -1) {
+      if (errno == EINTR) {
+        continue;
+      }
+      ESP_LOGW(TAG, "select() failed: errno=%d", errno);
+      break;
+    }
+
+    if (stdout_open && FD_ISSET(stdout_pipe[0], &read_fds)) {
+      ssize_t count = ::read(stdout_pipe[0], buffer.data(), buffer.size());
+      if (count > 0) {
+        result.stdout_output.append(buffer.data(), static_cast<size_t>(count));
+      } else if (count == 0) {
+        stdout_open = false;
+      } else if (errno != EINTR) {
+        ESP_LOGW(TAG, "Reading stdout failed: errno=%d", errno);
+        stdout_open = false;
+      }
+    }
+
+    if (stderr_open && FD_ISSET(stderr_pipe[0], &read_fds)) {
+      ssize_t count = ::read(stderr_pipe[0], buffer.data(), buffer.size());
+      if (count > 0) {
+        result.stderr_output.append(buffer.data(), static_cast<size_t>(count));
+      } else if (count == 0) {
+        stderr_open = false;
+      } else if (errno != EINTR) {
+        ESP_LOGW(TAG, "Reading stderr failed: errno=%d", errno);
+        stderr_open = false;
+      }
+    }
+  }
+
+  close(stdout_pipe[0]);
+  close(stderr_pipe[0]);
+
+  int status = 0;
+  if (waitpid(pid, &status, 0) == -1) {
+    ESP_LOGE(TAG, "waitpid failed: errno=%d", errno);
+    result.exit_code = -1;
+    return result;
+  }
+
+  if (WIFEXITED(status)) {
+    result.exit_code = WEXITSTATUS(status);
+  } else if (WIFSIGNALED(status)) {
+    result.exit_code = 128 + WTERMSIG(status);
+  } else {
+    result.exit_code = -1;
+  }
+
+  return result;
+}
+
+}  // namespace host
+}  // namespace esphome
+
+#endif  // USE_HOST

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -25,31 +25,6 @@ namespace host {
 
 static const char *const TAG = "host.shell";
 
-static std::string sanitize_for_state(const std::string &input) {
-  std::string sanitized;
-  sanitized.reserve(input.size());
-  for (unsigned char ch : input) {
-    switch (ch) {
-      case '\r':
-        // ignore carriage returns entirely
-        break;
-      case '\n':
-        sanitized += "\\n";
-        break;
-      case '\t':
-        sanitized += "\\t";
-        break;
-      default:
-        // Drop other control characters that can't be represented in HA states.
-        if (ch >= 0x20 && ch != 0x7F) {
-          sanitized.push_back(static_cast<char>(ch));
-        }
-        break;
-    }
-  }
-  return sanitized;
-}
-
 static bool create_pipe(int fds[2]) {
 #ifdef O_CLOEXEC
   if (pipe2(fds, O_CLOEXEC) == 0) {
@@ -205,9 +180,6 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
   } else {
     result.exit_code = -1;
   }
-
-  result.stdout_output = sanitize_for_state(result.stdout_output);
-  result.stderr_output = sanitize_for_state(result.stderr_output);
 
   ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
 

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -94,6 +94,9 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     }
     envp.push_back(nullptr);
 
+    ESP_LOGD(TAG, "Executing command with shell '%s' and %zu custom env vars: %s", shell.c_str(),
+             options.environment.size(), command.c_str());
+
     if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 || dup2(stderr_pipe[1], STDERR_FILENO) == -1) {
       _exit(127);
     }
@@ -177,6 +180,8 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
   } else {
     result.exit_code = -1;
   }
+
+  ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
 
   return result;
 }

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -181,6 +181,8 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     result.exit_code = -1;
   }
 
+  ESP_LOGD(TAG, "Command stdout:\n%s", result.stdout_output.c_str());
+  ESP_LOGD(TAG, "Command stderr:\n%s", result.stderr_output.c_str());
   ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
 
   return result;

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -25,6 +25,31 @@ namespace host {
 
 static const char *const TAG = "host.shell";
 
+static std::string sanitize_for_state(const std::string &input) {
+  std::string sanitized;
+  sanitized.reserve(input.size());
+  for (unsigned char ch : input) {
+    switch (ch) {
+      case '\r':
+        // ignore carriage returns entirely
+        break;
+      case '\n':
+        sanitized += "\\n";
+        break;
+      case '\t':
+        sanitized += "\\t";
+        break;
+      default:
+        // Drop other control characters that can't be represented in HA states.
+        if (ch >= 0x20 && ch != 0x7F) {
+          sanitized.push_back(static_cast<char>(ch));
+        }
+        break;
+    }
+  }
+  return sanitized;
+}
+
 static bool create_pipe(int fds[2]) {
 #ifdef O_CLOEXEC
   if (pipe2(fds, O_CLOEXEC) == 0) {
@@ -180,6 +205,9 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
   } else {
     result.exit_code = -1;
   }
+
+  result.stdout_output = sanitize_for_state(result.stdout_output);
+  result.stderr_output = sanitize_for_state(result.stderr_output);
 
   ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
 

--- a/esphome/components/host/shell_command.h
+++ b/esphome/components/host/shell_command.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef USE_HOST
+
+#include <string>
+
+namespace esphome {
+namespace host {
+
+struct ShellCommandResult {
+  int exit_code{-1};
+  std::string stdout_output;
+  std::string stderr_output;
+};
+
+struct ShellCommandOptions {
+  std::string shell{"/bin/sh"};
+  std::vector<std::pair<std::string, std::string>> environment;
+};
+
+ShellCommandResult execute_shell_command(const std::string &command,
+                                         const ShellCommandOptions &options = {});
+
+}  // namespace host
+}  // namespace esphome
+
+#endif  // USE_HOST

--- a/esphome/components/host/shell_command.h
+++ b/esphome/components/host/shell_command.h
@@ -3,6 +3,8 @@
 #ifdef USE_HOST
 
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace esphome {
 namespace host {


### PR DESCRIPTION
## Summary
- add a host shell command helper that runs quoted shell commands and returns exit status, stdout, and stderr for use in lambdas
- include the host shell command header automatically when building for the host platform
- harden pipe creation for the helper by using close-on-exec pipes and failing fast when redirections cannot be set up
- allow selecting an explicit shell and injecting custom environment variables per command

## Testing
- ⚠️ `python -m pytest -o addopts= tests/integration/test_host_mode_climate_control.py` (fails: missing dependency pytest_asyncio)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69525bee8bf88327b3dce095cba75e9b)