### PR TITLE
Log environment variables for host shell commands

### DIFF
--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -80,14 +80,6 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     for (const auto &kv : options.environment) {
       env_map[kv.first] = kv.second;
     }
-    std::vector<std::string> custom_env_strings;
-    custom_env_strings.reserve(options.environment.size());
-    for (const auto &kv : options.environment) {
-      auto it = env_map.find(kv.first);
-      if (it != env_map.end()) {
-        custom_env_strings.push_back(it->first + "=" + it->second);
-      }
-    }
 
     std::vector<std::string> env_strings;
     env_strings.reserve(env_map.size());
@@ -103,19 +95,16 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     envp.push_back(nullptr);
 
     std::string env_log;
-    if (custom_env_strings.empty()) {
-      env_log = "none";
-    } else {
-      for (size_t i = 0; i < custom_env_strings.size(); i++) {
-        if (i != 0) {
-          env_log.append(", ");
-        }
-        env_log.append(custom_env_strings[i]);
+    for (size_t i = 0; i < env_strings.size(); i++) {
+      if (i != 0) {
+        env_log.append(", ");
       }
+      env_log.append(env_strings[i]);
     }
 
-    ESP_LOGD(TAG, "Executing command with shell '%s' and %zu custom env vars (%s): %s", shell.c_str(),
-             options.environment.size(), env_log.c_str(), command.c_str());
+    ESP_LOGD(TAG, "Executing command with shell '%s', %zu custom env vars, %zu total env vars: %s", shell.c_str(),
+             options.environment.size(), env_strings.size(), env_log.c_str());
+    ESP_LOGD(TAG, "Command: %s", command.c_str());
 
     if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 || dup2(stderr_pipe[1], STDERR_FILENO) == -1) {
       _exit(127);

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -80,6 +80,14 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     for (const auto &kv : options.environment) {
       env_map[kv.first] = kv.second;
     }
+    std::vector<std::string> custom_env_strings;
+    custom_env_strings.reserve(options.environment.size());
+    for (const auto &kv : options.environment) {
+      auto it = env_map.find(kv.first);
+      if (it != env_map.end()) {
+        custom_env_strings.push_back(it->first + "=" + it->second);
+      }
+    }
 
     std::vector<std::string> env_strings;
     env_strings.reserve(env_map.size());
@@ -94,8 +102,20 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     }
     envp.push_back(nullptr);
 
-    ESP_LOGD(TAG, "Executing command with shell '%s' and %zu custom env vars: %s", shell.c_str(),
-             options.environment.size(), command.c_str());
+    std::string env_log;
+    if (custom_env_strings.empty()) {
+      env_log = "none";
+    } else {
+      for (size_t i = 0; i < custom_env_strings.size(); i++) {
+        if (i != 0) {
+          env_log.append(", ");
+        }
+        env_log.append(custom_env_strings[i]);
+      }
+    }
+
+    ESP_LOGD(TAG, "Executing command with shell '%s' and %zu custom env vars (%s): %s", shell.c_str(),
+             options.environment.size(), env_log.c_str(), command.c_str());
 
     if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 || dup2(stderr_pipe[1], STDERR_FILENO) == -1) {
       _exit(127);

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -419,35 +419,6 @@ assert state.missing_state is False
 
 #### 7. Debugging Tips
 
-##### Host Shell Command Boolean Parsing Example
-When publishing a template switch state from a host shell command, ensure the lambda returns a boolean based on the parsed `On`/`Off` output.
-
-```yaml
-interval:
-  - interval: 5s
-    then:
-      - switch.template.publish:
-          id: host_display_switch
-          state: !lambda |-
-            esphome::host::ShellCommandOptions opts;
-            opts.environment = {
-              {"DISPLAY", ":0.0"},
-            };
-            auto result = esphome::host::execute_shell_command(
-                "xset -q | awk '/Monitor is/ {print $NF; exit}'", opts);
-            auto load_str = result.stdout_output;
-            load_str.erase(std::remove_if(load_str.begin(), load_str.end(), ::isspace), load_str.end());
-            auto parsed = parse_on_off(load_str.c_str(), "On", "Off");
-            if (parsed == esphome::PARSE_ON) {
-              return true;
-            }
-            if (parsed == esphome::PARSE_OFF) {
-              return false;
-            }
-            ESP_LOGW("host.shell", "Unable to parse monitor state from output: %s", load_str.c_str());
-            return id(host_display_switch).state;
-```
-
 - Use `pytest -s` to see ESPHome output during tests
 - Add descriptive failure messages to assertions
 - Use `pytest.fail()` with detailed error info for timeouts

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -419,6 +419,35 @@ assert state.missing_state is False
 
 #### 7. Debugging Tips
 
+##### Host Shell Command Boolean Parsing Example
+When publishing a template switch state from a host shell command, ensure the lambda returns a boolean based on the parsed `On`/`Off` output.
+
+```yaml
+interval:
+  - interval: 5s
+    then:
+      - switch.template.publish:
+          id: host_display_switch
+          state: !lambda |-
+            esphome::host::ShellCommandOptions opts;
+            opts.environment = {
+              {"DISPLAY", ":0.0"},
+            };
+            auto result = esphome::host::execute_shell_command(
+                "xset -q | awk '/Monitor is/ {print $NF; exit}'", opts);
+            auto load_str = result.stdout_output;
+            load_str.erase(std::remove_if(load_str.begin(), load_str.end(), ::isspace), load_str.end());
+            auto parsed = parse_on_off(load_str.c_str(), "On", "Off");
+            if (parsed == esphome::PARSE_ON) {
+              return true;
+            }
+            if (parsed == esphome::PARSE_OFF) {
+              return false;
+            }
+            ESP_LOGW("host.shell", "Unable to parse monitor state from output: %s", load_str.c_str());
+            return id(host_display_switch).state;
+```
+
 - Use `pytest -s` to see ESPHome output during tests
 - Add descriptive failure messages to assertions
 - Use `pytest.fail()` with detailed error info for timeouts


### PR DESCRIPTION
## Summary
- log the resolved custom environment variables when running host shell commands in lambdas
- keep debug output showing the shell, command, and final custom environment values

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e111840c8327bf362465957d8ee6)