### PR TITLE
Use MAC_ADDRESS_SIZE in bthome MAC formatting

### DIFF
--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -10,9 +10,6 @@
 namespace esphome {
 namespace bthome_mithermometer {
 
-using esphome::MAC_ADDRESS_PRETTY_BUFFER_SIZE;
-using esphome::MAC_ADDRESS_SIZE;
-
 static const char *const TAG = "bthome_mithermometer";
 
 static std::string format_mac_address(uint64_t address) {

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -13,12 +13,12 @@ namespace bthome_mithermometer {
 static const char *const TAG = "bthome_mithermometer";
 
 static std::string format_mac_address(uint64_t address) {
-  std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
-  for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
-    mac[i] = (address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
+  std::array<uint8_t, ::esphome::MAC_ADDRESS_SIZE> mac{};
+  for (size_t i = 0; i < ::esphome::MAC_ADDRESS_SIZE; i++) {
+    mac[i] = (address >> ((::esphome::MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
   }
 
-  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  char buffer[::esphome::MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   format_mac_addr_upper(mac.data(), buffer);
   return buffer;
 }

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -12,13 +12,15 @@ namespace bthome_mithermometer {
 
 static const char *const TAG = "bthome_mithermometer";
 
+static const int MAC_ADDRESS_SIZE = 6;
+
 static std::string format_mac_address(uint64_t address) {
   std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
   for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
     mac[i] = (address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
   }
 
-  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  char buffer[MAC_ADDRESS_SIZE * 3];
   format_mac_addr_upper(mac.data(), buffer);
   return buffer;
 }

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -13,12 +13,12 @@ namespace bthome_mithermometer {
 static const char *const TAG = "bthome_mithermometer";
 
 static std::string format_mac_address(uint64_t address) {
-  std::array<uint8_t, 6> mac{};
-  for (int i = 0; i < 6; i++) {
-    mac[i] = (address >> ((5 - i) * 8)) & 0xFF;
+  std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
+  for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
+    mac[i] = (address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
   }
 
-  char buffer[18];
+  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   format_mac_addr_upper(mac.data(), buffer);
   return buffer;
 }

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -10,15 +10,18 @@
 namespace esphome {
 namespace bthome_mithermometer {
 
+using esphome::MAC_ADDRESS_PRETTY_BUFFER_SIZE;
+using esphome::MAC_ADDRESS_SIZE;
+
 static const char *const TAG = "bthome_mithermometer";
 
 static std::string format_mac_address(uint64_t address) {
-  std::array<uint8_t, ::esphome::MAC_ADDRESS_SIZE> mac{};
-  for (size_t i = 0; i < ::esphome::MAC_ADDRESS_SIZE; i++) {
-    mac[i] = (address >> ((::esphome::MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
+  std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
+  for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
+    mac[i] = (address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
   }
 
-  char buffer[::esphome::MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   format_mac_addr_upper(mac.data(), buffer);
   return buffer;
 }


### PR DESCRIPTION
## Summary
- use MAC_ADDRESS_SIZE for BTHome Mi Thermometer MAC formatting array and iteration
- size the formatting buffer with the shared MAC address constant

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695665ce470c83279dda944cfc4b9847)