### PR TITLE
Handle host signals and clean up on exit

### DIFF
--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -3,9 +3,15 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "preferences.h"
+#ifdef USE_LOGGER
+#include "esphome/components/logger/logger.h"
+#endif
 
 #include <sched.h>
 #include <time.h>
+#include <atomic>
+#include <cstdio>
+#include <csignal>
 #include <cmath>
 #include <cstdlib>
 
@@ -66,12 +72,32 @@ uint32_t arch_get_cpu_freq_hz() { return 1000000000U; }
 
 void setup();
 void loop();
+
+namespace {
+std::atomic_bool stop_requested{false};
+
+void handle_signal(int) { stop_requested.store(true); }
+}  // namespace
+
 int main() {
+  std::signal(SIGTERM, handle_signal);
+  std::signal(SIGINT, handle_signal);
+
   esphome::host::setup_preferences();
   setup();
-  while (true) {
+  while (!stop_requested.load()) {
     loop();
   }
+
+  if (esphome::global_preferences != nullptr) {
+    esphome::global_preferences->sync();
+  }
+#ifdef USE_LOGGER
+  if (esphome::logger::global_logger != nullptr) {
+    std::fflush(stdout);
+  }
+#endif
+  return 0;
 }
 
 #endif  // USE_HOST


### PR DESCRIPTION
## Summary
- install SIGTERM/SIGINT handlers to request shutdown for the host main loop
- break out of the main loop when a stop is requested and perform cleanup
- flush stored preferences and logger output before exiting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bbc2cfd748327ba9733d496912027)