### PR TITLE
Add host preferences path override

### DIFF
--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -13,6 +13,8 @@ from esphome.core import CORE
 
 from .const import KEY_HOST
 
+CONF_PREFERENCES_PATH = "preferences_path"
+
 # force import gpio to register pin schema
 from .gpio import host_pin_to_code  # noqa
 
@@ -33,6 +35,9 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_MAC_ADDRESS, default="98:35:69:ab:f6:79"): cv.mac_address,
+            cv.Optional(CONF_PREFERENCES_PATH): cv.All(
+                cv.string_strict, cv.Length(min=1)
+            ),
         }
     ),
     set_core_data,
@@ -42,6 +47,8 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     cg.add_build_flag("-DUSE_HOST")
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
+    if preferences_path := config.get(CONF_PREFERENCES_PATH):
+        cg.add_define("ESPHOME_HOST_PREFERENCES_PATH", preferences_path)
     cg.add_build_flag("-std=gnu++20")
     cg.add_define("ESPHOME_BOARD", "host")
     cg.add_define(ThreadModel.MULTI_ATOMICS)

--- a/esphome/components/host/preferences.cpp
+++ b/esphome/components/host/preferences.cpp
@@ -36,6 +36,7 @@ void HostPreferences::setup_() {
   }
 
   fs::path prefs_dir = fs::path(root_path) / ".esphome" / "prefs";
+  ESP_LOGD(TAG, "Using host preferences directory: '%s'", prefs_dir.string().c_str());
   std::error_code ec;
   fs::create_directories(prefs_dir, ec);
   if (ec) {

--- a/esphome/components/host/preferences.cpp
+++ b/esphome/components/host/preferences.cpp
@@ -1,9 +1,11 @@
 #ifdef USE_HOST
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include "preferences.h"
 #include "esphome/core/application.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace host {
@@ -14,13 +16,47 @@ static const char *const TAG = "host.preferences";
 void HostPreferences::setup_() {
   if (this->setup_complete_)
     return;
-  this->filename_.append(getenv("HOME"));
-  this->filename_.append("/.esphome");
-  this->filename_.append("/prefs");
-  fs::create_directories(this->filename_);
-  this->filename_.append("/");
-  this->filename_.append(App.get_name());
-  this->filename_.append(".prefs");
+  this->filename_.clear();
+
+  std::string root_path;
+#ifdef ESPHOME_HOST_PREFERENCES_PATH
+  root_path = ESPHOME_HOST_PREFERENCES_PATH;
+#endif
+
+  if (root_path.empty()) {
+    const char *home = getenv("HOME");
+    if (home != nullptr) {
+      root_path = home;
+    }
+  }
+
+  if (root_path.empty()) {
+    ESP_LOGE(TAG, "No preferences path configured and HOME environment variable not set.");
+    return;
+  }
+
+  fs::path prefs_dir = fs::path(root_path) / ".esphome" / "prefs";
+  std::error_code ec;
+  fs::create_directories(prefs_dir, ec);
+  if (ec) {
+    ESP_LOGE(TAG, "Failed to create preferences directory '%s': %s", prefs_dir.string().c_str(),
+             ec.message().c_str());
+    return;
+  }
+
+  const auto writable_test = prefs_dir / ".prefs_write_test";
+  {
+    std::ofstream test_file(writable_test, std::ios::out | std::ios::trunc);
+    test_file << "";
+    if (!test_file.good()) {
+      ESP_LOGE(TAG, "Preferences directory '%s' is not writable; please check permissions.",
+               prefs_dir.string().c_str());
+      return;
+    }
+  }
+  fs::remove(writable_test, ec);
+
+  this->filename_ = (prefs_dir / (std::string(App.get_name()) + ".prefs")).string();
   FILE *fp = fopen(this->filename_.c_str(), "rb");
   if (fp != nullptr) {
     while (!feof((fp))) {
@@ -43,7 +79,15 @@ void HostPreferences::setup_() {
 
 bool HostPreferences::sync() {
   this->setup_();
+  if (!this->setup_complete_) {
+    ESP_LOGE(TAG, "Preferences not initialized; unable to sync data to disk.");
+    return false;
+  }
   FILE *fp = fopen(this->filename_.c_str(), "wb");
+  if (fp == nullptr) {
+    ESP_LOGE(TAG, "Failed to open preferences file '%s' for writing.", this->filename_.c_str());
+    return false;
+  }
   std::map<uint32_t, std::vector<uint8_t>>::iterator it;
 
   for (it = this->data.begin(); it != this->data.end(); ++it) {

--- a/esphome/components/host/preferences.h
+++ b/esphome/components/host/preferences.h
@@ -33,6 +33,8 @@ class HostPreferences : public ESPPreferences {
     if (len > 255)
       return false;
     this->setup_();
+    if (!this->setup_complete_)
+      return false;
     std::vector vec(data, data + len);
     this->data[key] = vec;
     return true;
@@ -42,6 +44,8 @@ class HostPreferences : public ESPPreferences {
     if (len > 255)
       return false;
     this->setup_();
+    if (!this->setup_complete_)
+      return false;
     auto it = this->data.find(key);
     if (it == this->data.end())
       return false;


### PR DESCRIPTION
## Summary
- add an optional `preferences_path` host configuration to override the preferences storage base directory
- create the host preferences directory with error handling, writable checks, and clearer logging
- guard preference operations when initialization fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bcc39016c8327af7cef96075e6851)