### PR TITLE
Add `use_shell` YAML option and argv-based host command executor; align shell argv[0]

### DIFF
--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 
-from .const import KEY_HOST
+from .const import CONF_USE_SHELL, KEY_HOST
 
 # force import gpio to register pin schema
 from .gpio import host_pin_to_code  # noqa
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_MAC_ADDRESS, default="98:35:69:ab:f6:79"): cv.mac_address,
+            cv.Optional(CONF_USE_SHELL, default=False): cv.boolean,
         }
     ),
     set_core_data,
@@ -42,6 +43,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     cg.add_build_flag("-DUSE_HOST")
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
+    cg.add_define("HOST_SHELL_COMMAND_USE_SHELL_DEFAULT", "true" if config[CONF_USE_SHELL] else "false")
     cg.add_build_flag("-std=gnu++20")
     cg.add_define("ESPHOME_BOARD", "host")
     cg.add_define(ThreadModel.MULTI_ATOMICS)

--- a/esphome/components/host/const.py
+++ b/esphome/components/host/const.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 
 KEY_HOST = "host"
+CONF_USE_SHELL = "use_shell"
 
 host_ns = cg.esphome_ns.namespace("host")

--- a/esphome/components/host/gpio.cpp
+++ b/esphome/components/host/gpio.cpp
@@ -2,6 +2,8 @@
 
 #include "gpio.h"
 #include "esphome/core/log.h"
+#include <algorithm>
+#include <string>
 
 namespace esphome {
 namespace host {
@@ -26,6 +28,13 @@ void HostGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::Interr
 void HostGPIOPin::pin_mode(gpio::Flags flags) { ESP_LOGD(TAG, "Setting pin %d mode to %02X", pin_, (uint32_t) flags); }
 
 size_t HostGPIOPin::dump_summary(char *buffer, size_t len) const { return snprintf(buffer, len, "GPIO%u", this->pin_); }
+
+std::string HostGPIOPin::dump_summary() const {
+  char buffer[GPIO_SUMMARY_MAX_LEN];
+  size_t len = this->dump_summary(buffer, sizeof(buffer));
+  len = std::min(len, sizeof(buffer) - 1);
+  return std::string(buffer, len);
+}
 
 bool HostGPIOPin::digital_read() { return inverted_; }
 void HostGPIOPin::digital_write(bool value) {

--- a/esphome/components/host/gpio.cpp
+++ b/esphome/components/host/gpio.cpp
@@ -2,8 +2,6 @@
 
 #include "gpio.h"
 #include "esphome/core/log.h"
-#include <algorithm>
-#include <string>
 
 namespace esphome {
 namespace host {
@@ -28,13 +26,6 @@ void HostGPIOPin::attach_interrupt(void (*func)(void *), void *arg, gpio::Interr
 void HostGPIOPin::pin_mode(gpio::Flags flags) { ESP_LOGD(TAG, "Setting pin %d mode to %02X", pin_, (uint32_t) flags); }
 
 size_t HostGPIOPin::dump_summary(char *buffer, size_t len) const { return snprintf(buffer, len, "GPIO%u", this->pin_); }
-
-std::string HostGPIOPin::dump_summary() const {
-  char buffer[GPIO_SUMMARY_MAX_LEN];
-  size_t len = this->dump_summary(buffer, sizeof(buffer));
-  len = std::min(len, sizeof(buffer) - 1);
-  return std::string(buffer, len);
-}
 
 bool HostGPIOPin::digital_read() { return inverted_; }
 void HostGPIOPin::digital_write(bool value) {

--- a/esphome/components/host/gpio.h
+++ b/esphome/components/host/gpio.h
@@ -17,7 +17,7 @@ class HostGPIOPin : public InternalGPIOPin {
   void pin_mode(gpio::Flags flags) override;
   bool digital_read() override;
   void digital_write(bool value) override;
-  size_t dump_summary(char *buffer, size_t len) const override;
+  size_t dump_summary(char *buffer, size_t len) const;
   void detach_interrupt() const override;
   ISRInternalGPIOPin to_isr() const override;
   uint8_t get_pin() const override { return pin_; }

--- a/esphome/components/host/gpio.h
+++ b/esphome/components/host/gpio.h
@@ -17,7 +17,8 @@ class HostGPIOPin : public InternalGPIOPin {
   void pin_mode(gpio::Flags flags) override;
   bool digital_read() override;
   void digital_write(bool value) override;
-  size_t dump_summary(char *buffer, size_t len) const override;
+  size_t dump_summary(char *buffer, size_t len) const;
+  std::string dump_summary() const override;
   void detach_interrupt() const override;
   ISRInternalGPIOPin to_isr() const override;
   uint8_t get_pin() const override { return pin_; }

--- a/esphome/components/host/gpio.h
+++ b/esphome/components/host/gpio.h
@@ -17,8 +17,7 @@ class HostGPIOPin : public InternalGPIOPin {
   void pin_mode(gpio::Flags flags) override;
   bool digital_read() override;
   void digital_write(bool value) override;
-  size_t dump_summary(char *buffer, size_t len) const;
-  std::string dump_summary() const override;
+  size_t dump_summary(char *buffer, size_t len) const override;
   void detach_interrupt() const override;
   ISRInternalGPIOPin to_isr() const override;
   uint8_t get_pin() const override { return pin_; }

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -112,7 +112,177 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     close(stdout_pipe[1]);
     close(stderr_pipe[0]);
     close(stderr_pipe[1]);
-    execle(shell.c_str(), "sh", "-c", command.c_str(), nullptr, envp.data());
+    execle(shell.c_str(), shell.c_str(), "-c", command.c_str(), nullptr, envp.data());
+    _exit(127);
+  }
+
+  close(stdout_pipe[1]);
+  close(stderr_pipe[1]);
+
+  bool stdout_open = true;
+  bool stderr_open = true;
+  std::array<char, 4096> buffer{};
+
+  while (stdout_open || stderr_open) {
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    int max_fd = -1;
+    if (stdout_open) {
+      FD_SET(stdout_pipe[0], &read_fds);
+      max_fd = std::max(max_fd, stdout_pipe[0]);
+    }
+    if (stderr_open) {
+      FD_SET(stderr_pipe[0], &read_fds);
+      max_fd = std::max(max_fd, stderr_pipe[0]);
+    }
+
+    int ready = select(max_fd + 1, &read_fds, nullptr, nullptr, nullptr);
+    if (ready == -1) {
+      if (errno == EINTR) {
+        continue;
+      }
+      ESP_LOGW(TAG, "select() failed: errno=%d", errno);
+      break;
+    }
+
+    if (stdout_open && FD_ISSET(stdout_pipe[0], &read_fds)) {
+      ssize_t count = ::read(stdout_pipe[0], buffer.data(), buffer.size());
+      if (count > 0) {
+        result.stdout_output.append(buffer.data(), static_cast<size_t>(count));
+      } else if (count == 0) {
+        stdout_open = false;
+      } else if (errno != EINTR) {
+        ESP_LOGW(TAG, "Reading stdout failed: errno=%d", errno);
+        stdout_open = false;
+      }
+    }
+
+    if (stderr_open && FD_ISSET(stderr_pipe[0], &read_fds)) {
+      ssize_t count = ::read(stderr_pipe[0], buffer.data(), buffer.size());
+      if (count > 0) {
+        result.stderr_output.append(buffer.data(), static_cast<size_t>(count));
+      } else if (count == 0) {
+        stderr_open = false;
+      } else if (errno != EINTR) {
+        ESP_LOGW(TAG, "Reading stderr failed: errno=%d", errno);
+        stderr_open = false;
+      }
+    }
+  }
+
+  close(stdout_pipe[0]);
+  close(stderr_pipe[0]);
+
+  int status = 0;
+  if (waitpid(pid, &status, 0) == -1) {
+    ESP_LOGE(TAG, "waitpid failed: errno=%d", errno);
+    result.exit_code = -1;
+    return result;
+  }
+
+  if (WIFEXITED(status)) {
+    result.exit_code = WEXITSTATUS(status);
+  } else if (WIFSIGNALED(status)) {
+    result.exit_code = 128 + WTERMSIG(status);
+  } else {
+    result.exit_code = -1;
+  }
+
+  ESP_LOGD(TAG, "Command stdout:\n%s", result.stdout_output.c_str());
+  if (!result.stderr_output.empty()) {
+    ESP_LOGE(TAG, "Command stderr:\n%s", result.stderr_output.c_str());
+  }
+  ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
+
+  return result;
+}
+
+ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options) {
+  ShellCommandResult result{};
+
+  if (args.empty()) {
+    ESP_LOGE(TAG, "execute_command requires at least one argument");
+    return result;
+  }
+
+  int stdout_pipe[2];
+  int stderr_pipe[2];
+  if (!create_pipe(stdout_pipe) || !create_pipe(stderr_pipe)) {
+    ESP_LOGE(TAG, "Creating pipes failed: errno=%d", errno);
+    return result;
+  }
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    ESP_LOGE(TAG, "Fork failed: errno=%d", errno);
+    close(stdout_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[0]);
+    close(stderr_pipe[1]);
+    return result;
+  }
+
+  if (pid == 0) {
+    std::string shell = options.shell.empty() ? "/bin/sh" : options.shell;
+
+    auto env_map = current_environment();
+    for (const auto &kv : options.environment) {
+      env_map[kv.first] = kv.second;
+    }
+
+    std::string env_log;
+    for (const auto &kv : options.environment) {
+      if (!env_log.empty()) {
+        env_log.append(", ");
+      }
+      env_log.append(kv.first);
+      env_log.append("=");
+      env_log.append(kv.second);
+    }
+
+    std::vector<char *> envp;
+    // strdup is used to allocate memory that remains valid after the map is out of scope.
+    // There is no memory leak since the process memory is replaced by execve/execle.
+    // if the exec* call fails, we immediately exit anyway
+    envp.reserve(env_map.size() + 1);
+    for (const auto &[k, v] : env_map) {
+      envp.push_back(strdup((k + "=" + v).c_str()));
+    }
+    envp.push_back(nullptr);
+
+    std::string command_desc;
+    for (size_t i = 0; i < args.size(); i++) {
+      if (i != 0) {
+        command_desc.append(" ");
+      }
+      command_desc.append(args[i]);
+    }
+
+    ESP_LOGD(TAG, "Executing command (%s) with %zu custom env vars: %s",
+             options.use_shell ? "via shell" : "direct execve", options.environment.size(), command_desc.c_str());
+    if (!env_log.empty()) {
+      ESP_LOGD(TAG, "Custom environment variables from YAML: %s", env_log.c_str());
+    }
+
+    if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 || dup2(stderr_pipe[1], STDERR_FILENO) == -1) {
+      _exit(127);
+    }
+    close(stdout_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[0]);
+    close(stderr_pipe[1]);
+
+    if (options.use_shell) {
+      execle(shell.c_str(), shell.c_str(), "-c", command_desc.c_str(), nullptr, envp.data());
+    } else {
+      std::vector<char *> argv;
+      argv.reserve(args.size() + 1);
+      for (const auto &arg : args) {
+        argv.push_back(const_cast<char *>(arg.c_str()));
+      }
+      argv.push_back(nullptr);
+      execve(args.front().c_str(), argv.data(), envp.data());
+    }
     _exit(127);
   }
 

--- a/esphome/components/host/shell_command.h
+++ b/esphome/components/host/shell_command.h
@@ -6,6 +6,10 @@
 #include <utility>
 #include <vector>
 
+#ifndef HOST_SHELL_COMMAND_USE_SHELL_DEFAULT
+#define HOST_SHELL_COMMAND_USE_SHELL_DEFAULT false
+#endif
+
 namespace esphome {
 namespace host {
 
@@ -18,9 +22,11 @@ struct ShellCommandResult {
 struct ShellCommandOptions {
   std::string shell{"/bin/sh"};
   std::vector<std::pair<std::string, std::string>> environment;
+  bool use_shell{HOST_SHELL_COMMAND_USE_SHELL_DEFAULT};
 };
 
 ShellCommandResult execute_shell_command(const std::string &command, const ShellCommandOptions &options = {});
+ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options = {});
 
 }  // namespace host
 }  // namespace esphome


### PR DESCRIPTION
### Motivation
- Provide a safer default by running host commands via direct `execve` semantics instead of always invoking a shell to reduce accidental shell injection.
- Allow projects to opt into shell-based execution via configuration rather than hardcoding the behavior.
- Ensure the child process `argv[0]` reflects the configured shell path when a shell is used to avoid misleading process names.
- Surface command output, exit codes, and errors reliably when executing host commands.

### Description
- Introduce the compile-time macro default `HOST_SHELL_COMMAND_USE_SHELL_DEFAULT` and wire it into `ShellCommandOptions` so `bool use_shell` defaults can be set from build config via `to_code`.
- Add a new YAML option `use_shell` (`CONF_USE_SHELL`) to the host platform schema and emit `HOST_SHELL_COMMAND_USE_SHELL_DEFAULT` with `cg.add_define` in `esphome/components/host/__init__.py`.
- Change `execute_shell_command` to pass the configured shell path as `argv[0]` when calling `execle`, and add robust non-blocking read/select, logging, and `waitpid` handling to collect stdout/stderr and exit code.
- Implement a new `execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options)` that forks and either calls `execve` for direct argv execution or `execle` when `use_shell` is true, preserving environment handling and logging.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc72e18088327a30611741606d087)