### PR TITLE
host: make `use_shell` macro numeric and add argv-based command execution

### DIFF
--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 
-from .const import KEY_HOST
+from .const import CONF_USE_SHELL, KEY_HOST
 
 # force import gpio to register pin schema
 from .gpio import host_pin_to_code  # noqa
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Optional(CONF_MAC_ADDRESS, default="98:35:69:ab:f6:79"): cv.mac_address,
+            cv.Optional(CONF_USE_SHELL, default=False): cv.boolean,
         }
     ),
     set_core_data,
@@ -42,6 +43,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     cg.add_build_flag("-DUSE_HOST")
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
+    cg.add_define("HOST_SHELL_COMMAND_USE_SHELL_DEFAULT", "1" if config[CONF_USE_SHELL] else "0")
     cg.add_build_flag("-std=gnu++20")
     cg.add_define("ESPHOME_BOARD", "host")
     cg.add_define(ThreadModel.MULTI_ATOMICS)

--- a/esphome/components/host/const.py
+++ b/esphome/components/host/const.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 
 KEY_HOST = "host"
+CONF_USE_SHELL = "use_shell"
 
 host_ns = cg.esphome_ns.namespace("host")

--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -112,7 +112,177 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
     close(stdout_pipe[1]);
     close(stderr_pipe[0]);
     close(stderr_pipe[1]);
-    execle(shell.c_str(), "sh", "-c", command.c_str(), nullptr, envp.data());
+    execle(shell.c_str(), shell.c_str(), "-c", command.c_str(), nullptr, envp.data());
+    _exit(127);
+  }
+
+  close(stdout_pipe[1]);
+  close(stderr_pipe[1]);
+
+  bool stdout_open = true;
+  bool stderr_open = true;
+  std::array<char, 4096> buffer{};
+
+  while (stdout_open || stderr_open) {
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    int max_fd = -1;
+    if (stdout_open) {
+      FD_SET(stdout_pipe[0], &read_fds);
+      max_fd = std::max(max_fd, stdout_pipe[0]);
+    }
+    if (stderr_open) {
+      FD_SET(stderr_pipe[0], &read_fds);
+      max_fd = std::max(max_fd, stderr_pipe[0]);
+    }
+
+    int ready = select(max_fd + 1, &read_fds, nullptr, nullptr, nullptr);
+    if (ready == -1) {
+      if (errno == EINTR) {
+        continue;
+      }
+      ESP_LOGW(TAG, "select() failed: errno=%d", errno);
+      break;
+    }
+
+    if (stdout_open && FD_ISSET(stdout_pipe[0], &read_fds)) {
+      ssize_t count = ::read(stdout_pipe[0], buffer.data(), buffer.size());
+      if (count > 0) {
+        result.stdout_output.append(buffer.data(), static_cast<size_t>(count));
+      } else if (count == 0) {
+        stdout_open = false;
+      } else if (errno != EINTR) {
+        ESP_LOGW(TAG, "Reading stdout failed: errno=%d", errno);
+        stdout_open = false;
+      }
+    }
+
+    if (stderr_open && FD_ISSET(stderr_pipe[0], &read_fds)) {
+      ssize_t count = ::read(stderr_pipe[0], buffer.data(), buffer.size());
+      if (count > 0) {
+        result.stderr_output.append(buffer.data(), static_cast<size_t>(count));
+      } else if (count == 0) {
+        stderr_open = false;
+      } else if (errno != EINTR) {
+        ESP_LOGW(TAG, "Reading stderr failed: errno=%d", errno);
+        stderr_open = false;
+      }
+    }
+  }
+
+  close(stdout_pipe[0]);
+  close(stderr_pipe[0]);
+
+  int status = 0;
+  if (waitpid(pid, &status, 0) == -1) {
+    ESP_LOGE(TAG, "waitpid failed: errno=%d", errno);
+    result.exit_code = -1;
+    return result;
+  }
+
+  if (WIFEXITED(status)) {
+    result.exit_code = WEXITSTATUS(status);
+  } else if (WIFSIGNALED(status)) {
+    result.exit_code = 128 + WTERMSIG(status);
+  } else {
+    result.exit_code = -1;
+  }
+
+  ESP_LOGD(TAG, "Command stdout:\n%s", result.stdout_output.c_str());
+  if (!result.stderr_output.empty()) {
+    ESP_LOGE(TAG, "Command stderr:\n%s", result.stderr_output.c_str());
+  }
+  ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
+
+  return result;
+}
+
+ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options) {
+  ShellCommandResult result{};
+
+  if (args.empty()) {
+    ESP_LOGE(TAG, "execute_command requires at least one argument");
+    return result;
+  }
+
+  int stdout_pipe[2];
+  int stderr_pipe[2];
+  if (!create_pipe(stdout_pipe) || !create_pipe(stderr_pipe)) {
+    ESP_LOGE(TAG, "Creating pipes failed: errno=%d", errno);
+    return result;
+  }
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    ESP_LOGE(TAG, "Fork failed: errno=%d", errno);
+    close(stdout_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[0]);
+    close(stderr_pipe[1]);
+    return result;
+  }
+
+  if (pid == 0) {
+    std::string shell = options.shell.empty() ? "/bin/sh" : options.shell;
+
+    auto env_map = current_environment();
+    for (const auto &kv : options.environment) {
+      env_map[kv.first] = kv.second;
+    }
+
+    std::string env_log;
+    for (const auto &kv : options.environment) {
+      if (!env_log.empty()) {
+        env_log.append(", ");
+      }
+      env_log.append(kv.first);
+      env_log.append("=");
+      env_log.append(kv.second);
+    }
+
+    std::vector<char *> envp;
+    // strdup is used to allocate memory that remains valid after the map is out of scope.
+    // There is no memory leak since the process memory is replaced by execve/execle.
+    // if the exec* call fails, we immediately exit anyway
+    envp.reserve(env_map.size() + 1);
+    for (const auto &[k, v] : env_map) {
+      envp.push_back(strdup((k + "=" + v).c_str()));
+    }
+    envp.push_back(nullptr);
+
+    std::string command_desc;
+    for (size_t i = 0; i < args.size(); i++) {
+      if (i != 0) {
+        command_desc.append(" ");
+      }
+      command_desc.append(args[i]);
+    }
+
+    ESP_LOGD(TAG, "Executing command (%s) with %zu custom env vars: %s",
+             options.use_shell ? "via shell" : "direct execve", options.environment.size(), command_desc.c_str());
+    if (!env_log.empty()) {
+      ESP_LOGD(TAG, "Custom environment variables from YAML: %s", env_log.c_str());
+    }
+
+    if (dup2(stdout_pipe[1], STDOUT_FILENO) == -1 || dup2(stderr_pipe[1], STDERR_FILENO) == -1) {
+      _exit(127);
+    }
+    close(stdout_pipe[0]);
+    close(stdout_pipe[1]);
+    close(stderr_pipe[0]);
+    close(stderr_pipe[1]);
+
+    if (options.use_shell) {
+      execle(shell.c_str(), shell.c_str(), "-c", command_desc.c_str(), nullptr, envp.data());
+    } else {
+      std::vector<char *> argv;
+      argv.reserve(args.size() + 1);
+      for (const auto &arg : args) {
+        argv.push_back(const_cast<char *>(arg.c_str()));
+      }
+      argv.push_back(nullptr);
+      execve(args.front().c_str(), argv.data(), envp.data());
+    }
     _exit(127);
   }
 

--- a/esphome/components/host/shell_command.h
+++ b/esphome/components/host/shell_command.h
@@ -6,6 +6,10 @@
 #include <utility>
 #include <vector>
 
+#ifndef HOST_SHELL_COMMAND_USE_SHELL_DEFAULT
+#define HOST_SHELL_COMMAND_USE_SHELL_DEFAULT 0
+#endif
+
 namespace esphome {
 namespace host {
 
@@ -18,9 +22,11 @@ struct ShellCommandResult {
 struct ShellCommandOptions {
   std::string shell{"/bin/sh"};
   std::vector<std::pair<std::string, std::string>> environment;
+  bool use_shell{HOST_SHELL_COMMAND_USE_SHELL_DEFAULT};
 };
 
 ShellCommandResult execute_shell_command(const std::string &command, const ShellCommandOptions &options = {});
+ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options = {});
 
 }  // namespace host
 }  // namespace esphome


### PR DESCRIPTION
### Motivation

- Fix a narrowing/typing issue by emitting a numeric `HOST_SHELL_COMMAND_USE_SHELL_DEFAULT` instead of a string literal to match the C++ boolean/macro usage.
- Expose a YAML-configurable `use_shell` option for the host platform so callers can choose shell-based or direct exec behavior via `use_shell`.
- Improve command execution robustness by supporting direct `execve` (argv-based) execution in addition to shell-based execution and by reliably capturing both `stdout` and `stderr`.

### Description

- Emit numeric defines from `esphome/components/host/__init__.py` with `cg.add_define("HOST_SHELL_COMMAND_USE_SHELL_DEFAULT", "1" if config[CONF_USE_SHELL] else "0")` and add the `CONF_USE_SHELL` schema entry.
- Add `CONF_USE_SHELL` to `esphome/components/host/const.py` so the host platform exposes the `use_shell` option.
- Change the compile-time default macro in `esphome/components/host/shell_command.h` to `#define HOST_SHELL_COMMAND_USE_SHELL_DEFAULT 0` and add the `execute_command` declaration.
- Extend `esphome/components/host/shell_command.cpp` to fix the `execle` argv[0] usage, add a new `execute_command` implementation that can `execve` with an argv vector when `use_shell` is false, and add robust pipe reading, waitpid handling, environment propagation, and logging.

### Testing

- No automated tests (CI/build) were run after these changes.
- (Note: edits were applied to the listed files and the changes were recorded locally.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc72e18088327a30611741606d087)