### PR TITLE
Add async host shell command APIs

### DIFF
--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <map>
 #include <string>
+#include <future>
 #include <cstring>
 #include <sys/select.h>
 #include <sys/types.h>
@@ -196,6 +197,11 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
   return result;
 }
 
+std::future<ShellCommandResult> execute_shell_command_async(const std::string &command,
+                                                            const ShellCommandOptions &options) {
+  return std::async(std::launch::async, [command, options]() { return execute_shell_command(command, options); });
+}
+
 ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options) {
   ShellCommandResult result{};
 
@@ -364,6 +370,11 @@ ShellCommandResult execute_command(const std::vector<std::string> &args, const S
   ESP_LOGD(TAG, "Command finished with exit code %d", result.exit_code);
 
   return result;
+}
+
+std::future<ShellCommandResult> execute_command_async(const std::vector<std::string> &args,
+                                                      const ShellCommandOptions &options) {
+  return std::async(std::launch::async, [args, options]() { return execute_command(args, options); });
 }
 
 }  // namespace esphome::host

--- a/esphome/components/host/shell_command.h
+++ b/esphome/components/host/shell_command.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <future>
 
 #ifndef HOST_SHELL_COMMAND_USE_SHELL_DEFAULT
 #define HOST_SHELL_COMMAND_USE_SHELL_DEFAULT 0
@@ -27,6 +28,10 @@ struct ShellCommandOptions {
 
 ShellCommandResult execute_shell_command(const std::string &command, const ShellCommandOptions &options = {});
 ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options = {});
+std::future<ShellCommandResult> execute_shell_command_async(const std::string &command,
+                                                            const ShellCommandOptions &options = {});
+std::future<ShellCommandResult> execute_command_async(const std::vector<std::string> &args,
+                                                      const ShellCommandOptions &options = {});
 
 }  // namespace host
 }  // namespace esphome


### PR DESCRIPTION
### Motivation
- Offload blocking shell execution from the caller thread to avoid stalling host code.
- Provide non-blocking APIs that return a `std::future` so callers can run commands asynchronously.
- Preserve existing synchronous APIs while exposing async wrappers for both shell strings and argument vectors.

### Description
- Added `#include <future>` and new declarations for `execute_shell_command_async` and `execute_command_async` to `esphome/components/host/shell_command.h`.
- Implemented async wrappers in `esphome/components/host/shell_command.cpp` using `std::async(std::launch::async, ...)` which call the existing `execute_shell_command` and `execute_command` functions.
- Modified only `esphome/components/host/shell_command.h` and `esphome/components/host/shell_command.cpp` to add the async helpers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d175cf7d88327acf44f537c866177)