### PR TITLE
Host: Add configurable preferences path and improve directory handling

### DIFF
--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 
-from .const import CONF_USE_SHELL, KEY_HOST
+from .const import CONF_PREFERENCES_PATH, CONF_USE_SHELL, KEY_HOST
 
 # force import gpio to register pin schema
 from .gpio import host_pin_to_code  # noqa
@@ -34,6 +34,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.Optional(CONF_MAC_ADDRESS, default="98:35:69:ab:f6:79"): cv.mac_address,
             cv.Optional(CONF_USE_SHELL, default=False): cv.boolean,
+            cv.Optional(CONF_PREFERENCES_PATH): cv.All(cv.string, cv.Length(min=1)),
         }
     ),
     set_core_data,
@@ -44,6 +45,8 @@ async def to_code(config):
     cg.add_build_flag("-DUSE_HOST")
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
     cg.add_define("HOST_SHELL_COMMAND_USE_SHELL_DEFAULT", config[CONF_USE_SHELL])
+    if CONF_PREFERENCES_PATH in config:
+        cg.add_define("ESPHOME_HOST_PREFERENCES_PATH", config[CONF_PREFERENCES_PATH])
     cg.add_build_flag("-std=gnu++20")
     cg.add_define("ESPHOME_BOARD", "host")
     cg.add_define(ThreadModel.MULTI_ATOMICS)

--- a/esphome/components/host/const.py
+++ b/esphome/components/host/const.py
@@ -2,5 +2,6 @@ import esphome.codegen as cg
 
 KEY_HOST = "host"
 CONF_USE_SHELL = "use_shell"
+CONF_PREFERENCES_PATH = "preferences_path"
 
 host_ns = cg.esphome_ns.namespace("host")

--- a/esphome/components/host/preferences.cpp
+++ b/esphome/components/host/preferences.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include "preferences.h"
 #include "esphome/core/application.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace host {
@@ -14,13 +15,36 @@ static const char *const TAG = "host.preferences";
 void HostPreferences::setup_() {
   if (this->setup_complete_)
     return;
-  this->filename_.append(getenv("HOME"));
-  this->filename_.append("/.esphome");
-  this->filename_.append("/prefs");
-  fs::create_directories(this->filename_);
-  this->filename_.append("/");
-  this->filename_.append(App.get_name());
-  this->filename_.append(".prefs");
+  fs::path preferences_root;
+#ifdef ESPHOME_HOST_PREFERENCES_PATH
+  preferences_root = ESPHOME_HOST_PREFERENCES_PATH;
+#else
+  const char *home = getenv("HOME");
+  if (home == nullptr || *home == '\0') {
+    ESP_LOGE(TAG, "HOME is not set and no host preferences path was configured.");
+    return;
+  }
+  preferences_root = fs::path(home) / ".esphome" / "prefs";
+#endif
+  std::string preferences_root_str = preferences_root.string();
+  std::error_code error;
+  fs::create_directories(preferences_root, error);
+  if (error) {
+    ESP_LOGE(TAG, "Failed to create preferences directory '%s': %s", preferences_root_str.c_str(),
+             error.message().c_str());
+    return;
+  }
+  std::error_code status_error;
+  fs::perms permissions = fs::status(preferences_root, status_error).permissions();
+  if (!status_error) {
+    fs::perms writable = fs::perms::owner_write | fs::perms::group_write | fs::perms::others_write;
+    if ((permissions & writable) == fs::perms::none) {
+      ESP_LOGE(TAG, "Preferences directory '%s' is not writable.", preferences_root_str.c_str());
+    }
+  }
+  fs::path preferences_file = preferences_root / (App.get_name() + std::string(".prefs"));
+  this->filename_ = preferences_file.string();
+  ESP_LOGD(TAG, "Using preferences path: %s", this->filename_.c_str());
   FILE *fp = fopen(this->filename_.c_str(), "rb");
   if (fp != nullptr) {
     while (!feof((fp))) {


### PR DESCRIPTION
### Motivation
- Allow overriding the host preferences storage location from the `host:` YAML config instead of always using `$HOME/.esphome/prefs`.
- Make `HostPreferences::setup_` robust when creating the preferences directory and surface clear error messages when the path cannot be created or written to.

### Description
- Added a new config constant `CONF_PREFERENCES_PATH` and an optional `host: preferences_path` entry to the `host` config schema, validated as a non-empty string.
- Pass the configured path into the host build as the compile-time define `ESPHOME_HOST_PREFERENCES_PATH` via `to_code` when present.
- Reworked `HostPreferences::setup_` in `esphome/components/host/preferences.cpp` to use `std::filesystem::path` with a compile-time override `ESPHOME_HOST_PREFERENCES_PATH`, fall back to `HOME` if unset, call `fs::create_directories` with an `std::error_code`, check directory permissions, and log clear errors using `ESP_LOGE` when creation or writability checks fail.
- After resolving the final preferences file path, store it in `this->filename_` and emit a debug log with `ESP_LOGD` showing the resolved preferences path.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb328e5408327b9ed17e8762a5d38)