### PR TITLE
Rename execute_shell_command to execute_host_command in host component

### DIFF
--- a/esphome/components/host/shell_command.cpp
+++ b/esphome/components/host/shell_command.cpp
@@ -51,7 +51,7 @@ static std::map<std::string, std::string> current_environment() {
   return env_map;
 }
 
-ShellCommandResult execute_shell_command(const std::string &command, const ShellCommandOptions &options) {
+ShellCommandResult execute_host_command(const std::string &command, const ShellCommandOptions &options) {
   ShellCommandResult result{};
 
   int stdout_pipe[2];
@@ -197,9 +197,9 @@ ShellCommandResult execute_shell_command(const std::string &command, const Shell
   return result;
 }
 
-std::future<ShellCommandResult> execute_shell_command_async(const std::string &command,
+std::future<ShellCommandResult> execute_host_command_async(const std::string &command,
                                                             const ShellCommandOptions &options) {
-  return std::async(std::launch::async, [command, options]() { return execute_shell_command(command, options); });
+  return std::async(std::launch::async, [command, options]() { return execute_host_command(command, options); });
 }
 
 ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options) {

--- a/esphome/components/host/shell_command.h
+++ b/esphome/components/host/shell_command.h
@@ -25,9 +25,9 @@ struct ShellCommandOptions {
   bool use_shell{HOST_SHELL_COMMAND_USE_SHELL_DEFAULT};
 };
 
-ShellCommandResult execute_shell_command(const std::string &command, const ShellCommandOptions &options = {});
+ShellCommandResult execute_host_command(const std::string &command, const ShellCommandOptions &options = {});
 ShellCommandResult execute_command(const std::vector<std::string> &args, const ShellCommandOptions &options = {});
-std::future<ShellCommandResult> execute_shell_command_async(const std::string &command,
+std::future<ShellCommandResult> execute_host_command_async(const std::string &command,
                                                             const ShellCommandOptions &options = {});
 std::future<ShellCommandResult> execute_command_async(const std::vector<std::string> &args,
                                                       const ShellCommandOptions &options = {});

--- a/tests/components/host/common.yaml
+++ b/tests/components/host/common.yaml
@@ -23,7 +23,7 @@ esphome:
         x = clamp_at_most(x, 40);
         assert(x == 40);
     - lambda: |-
-        auto result = esphome::host::execute_shell_command("hostname");
+        auto result = esphome::host::execute_host_command("hostname");
         id(last_exit_code).publish_state(result.exit_code);
         id(last_stdout).publish_state(result.stdout_output.substr(0, 255));
         id(last_stderr).publish_state(result.stderr_output);


### PR DESCRIPTION
### Motivation
- Clarify the host component API by renaming the shell helper from `execute_shell_command` to `execute_host_command` to better reflect its domain and usage.

### Description
- Rename the synchronous and asynchronous functions in `esphome/components/host/shell_command.h` from `execute_shell_command`/`execute_shell_command_async` to `execute_host_command`/`execute_host_command_async` and update the implementation in `esphome/components/host/shell_command.cpp` accordingly.
- Update the host component test YAML `tests/components/host/common.yaml` to call `esphome::host::execute_host_command("hostname")` instead of the old name.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0c8372e0832798fac189c68b1fa8)