### PR TITLE
Add bindkey (AES-CCM) decryption support for BTHome MiThermometer

### DIFF
--- a/esphome/components/bthome_mithermometer/__init__.py
+++ b/esphome/components/bthome_mithermometer/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import esp32_ble_tracker
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_MAC_ADDRESS
+from esphome.const import CONF_BINDKEY, CONF_ID, CONF_MAC_ADDRESS
 
 CODEOWNERS = ["@nagyrobi"]
 DEPENDENCIES = ["esp32_ble_tracker"]
@@ -22,6 +22,7 @@ def bthome_mithermometer_base_schema(extra_schema=None):
             {
                 cv.GenerateID(CONF_ID): cv.declare_id(BTHomeMiThermometer),
                 cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+                cv.Optional(CONF_BINDKEY): cv.bind_key,
             }
         )
         .extend(BLE_DEVICE_SCHEMA)
@@ -34,3 +35,5 @@ async def setup_bthome_mithermometer(var, config):
     await cg.register_component(var, config)
     await esp32_ble_tracker.register_ble_device(var, config)
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
+    if CONF_BINDKEY in config:
+        cg.add(var.set_bindkey(config[CONF_BINDKEY]))

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -4,14 +4,21 @@
 #include "esphome/core/log.h"
 
 #include <array>
+#include <cstring>
 #include <span>
 
 #ifdef USE_ESP32
+
+#include "mbedtls/ccm.h"
 
 namespace esphome {
 namespace bthome_mithermometer {
 
 static const char *const TAG = "bthome_mithermometer";
+static constexpr size_t BTHOME_BINDKEY_SIZE = 16;
+static constexpr size_t BTHOME_NONCE_SIZE = 13;
+static constexpr size_t BTHOME_MIC_SIZE = 4;
+static constexpr size_t BTHOME_COUNTER_SIZE = 4;
 
 static const char *format_mac_address(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buffer, uint64_t address) {
   std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
@@ -130,6 +137,11 @@ void BTHomeMiThermometer::dump_config() {
   char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   ESP_LOGCONFIG(TAG, "BTHome MiThermometer");
   ESP_LOGCONFIG(TAG, "  MAC Address: %s", format_mac_address(addr_buf, this->address_));
+  if (this->has_bindkey_) {
+    char bindkey_hex[format_hex_pretty_size(BTHOME_BINDKEY_SIZE)];
+    ESP_LOGCONFIG(TAG, "  Bindkey: %s",
+                  format_hex_pretty_to(bindkey_hex, this->bindkey_, BTHOME_BINDKEY_SIZE, '.'));
+  }
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
@@ -148,6 +160,56 @@ bool BTHomeMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &dev
     this->signal_strength_->publish_state(device.get_rssi());
   }
   return matched;
+}
+
+void BTHomeMiThermometer::set_bindkey(const char *bindkey) {
+  parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_));
+  this->has_bindkey_ = true;
+}
+
+bool BTHomeMiThermometer::decrypt_bthome_payload_(const std::vector<uint8_t> &data, uint64_t source_address,
+                                                 std::vector<uint8_t> &payload) const {
+  if (data.size() <= 1 + BTHOME_COUNTER_SIZE + BTHOME_MIC_SIZE) {
+    ESP_LOGVV(TAG, "Encrypted BTHome payload too short: %zu", data.size());
+    return false;
+  }
+
+  const size_t ciphertext_size = data.size() - 1 - BTHOME_COUNTER_SIZE - BTHOME_MIC_SIZE;
+  payload.resize(ciphertext_size);
+
+  std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
+  for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
+    mac[i] = (source_address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
+  }
+
+  std::array<uint8_t, BTHOME_NONCE_SIZE> nonce{};
+  memcpy(nonce.data(), mac.data(), mac.size());
+  nonce[6] = 0xD2;
+  nonce[7] = 0xFC;
+  nonce[8] = data[0];
+  memcpy(nonce.data() + 9, &data[data.size() - BTHOME_COUNTER_SIZE - BTHOME_MIC_SIZE], BTHOME_COUNTER_SIZE);
+
+  const uint8_t *ciphertext = data.data() + 1;
+  const uint8_t *mic = data.data() + data.size() - BTHOME_MIC_SIZE;
+
+  mbedtls_ccm_context ctx;
+  mbedtls_ccm_init(&ctx);
+
+  int ret = mbedtls_ccm_setkey(&ctx, MBEDTLS_CIPHER_ID_AES, this->bindkey_, BTHOME_BINDKEY_SIZE * 8);
+  if (ret) {
+    ESP_LOGVV(TAG, "mbedtls_ccm_setkey() failed.");
+    mbedtls_ccm_free(&ctx);
+    return false;
+  }
+
+  ret = mbedtls_ccm_auth_decrypt(&ctx, ciphertext_size, nonce.data(), nonce.size(), nullptr, 0, ciphertext,
+                                 payload.data(), mic, BTHOME_MIC_SIZE);
+  mbedtls_ccm_free(&ctx);
+  if (ret) {
+    ESP_LOGVV(TAG, "BTHome decryption failed (ret=%d).", ret);
+    return false;
+  }
+  return true;
 }
 
 bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceData &service_data,
@@ -173,51 +235,74 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
     return false;
   }
 
-  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-  if (is_encrypted) {
-    ESP_LOGV(TAG, "Ignoring encrypted BTHome frame from %s", device.address_str_to(addr_buf));
+  if (is_encrypted && !this->has_bindkey_) {
+    char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+    ESP_LOGV(TAG, "Ignoring encrypted BTHome frame without bindkey from %s", device.address_str_to(addr_buf));
     return false;
   }
 
-  size_t payload_index = 1;
+  if (!is_encrypted && this->has_bindkey_) {
+    char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+    ESP_LOGV(TAG, "Ignoring unencrypted BTHome frame for bindkey device %s", device.address_str_to(addr_buf));
+    return false;
+  }
+
   uint64_t source_address = device.address_uint64();
+  std::vector<uint8_t> decrypted_payload;
+  const uint8_t *payload = nullptr;
+  size_t payload_size = 0;
+
+  if (is_encrypted) {
+    if (!this->decrypt_bthome_payload_(data, source_address, decrypted_payload)) {
+      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      ESP_LOGVV(TAG, "Failed to decrypt BTHome frame from %s", device.address_str_to(addr_buf));
+      return false;
+    }
+    payload = decrypted_payload.data();
+    payload_size = decrypted_payload.size();
+  } else {
+    payload = data.data() + 1;
+    payload_size = data.size() - 1;
+  }
 
   if (mac_included) {
-    if (data.size() < 7) {
+    if (payload_size < 6) {
       ESP_LOGVV(TAG, "BTHome payload missing MAC address");
       return false;
     }
     source_address = 0;
     for (int i = 5; i >= 0; i--) {
-      source_address = (source_address << 8) | data[1 + i];
+      source_address = (source_address << 8) | payload[i];
     }
-    payload_index = 7;
+    payload += 6;
+    payload_size -= 6;
   }
 
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   if (source_address != this->address_) {
     ESP_LOGVV(TAG, "BTHome frame from unexpected device %s", format_mac_address(addr_buf, source_address));
     return false;
   }
 
-  if (payload_index >= data.size()) {
+  if (payload_size == 0) {
     ESP_LOGVV(TAG, "BTHome payload empty after header");
     return false;
   }
 
   bool reported = false;
-  size_t offset = payload_index;
+  size_t offset = 0;
   uint8_t last_type = 0;
 
-  while (offset < data.size()) {
-    const uint8_t obj_type = data[offset++];
+  while (offset < payload_size) {
+    const uint8_t obj_type = payload[offset++];
     size_t value_length = 0;
     bool has_length_byte = obj_type == 0x53;  // text objects include explicit length
 
     if (has_length_byte) {
-      if (offset >= data.size()) {
+      if (offset >= payload_size) {
         break;
       }
-      value_length = data[offset++];
+      value_length = payload[offset++];
     } else {
       if (!get_bthome_value_length(obj_type, value_length)) {
         ESP_LOGVV(TAG, "Unknown BTHome object 0x%02X", obj_type);
@@ -229,12 +314,12 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
       break;
     }
 
-    if (offset + value_length > data.size()) {
+    if (offset + value_length > payload_size) {
       ESP_LOGVV(TAG, "BTHome object length exceeds payload");
       break;
     }
 
-    const uint8_t *value = &data[offset];
+    const uint8_t *value = &payload[offset];
     offset += value_length;
 
     if (obj_type < last_type) {

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -235,19 +235,33 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
     return false;
   }
 
+  uint64_t source_address = device.address_uint64();
+  bool address_matches = source_address == this->address_;
+  if (!is_encrypted && mac_included && data.size() >= 7) {
+    uint64_t advertised_address = 0;
+    for (int i = 5; i >= 0; i--) {
+      advertised_address = (advertised_address << 8) | data[1 + i];
+    }
+    address_matches = address_matches || advertised_address == this->address_;
+  }
+
   if (is_encrypted && !this->has_bindkey_) {
-    char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-    ESP_LOGE(TAG, "Encrypted BTHome frame received but no bindkey configured for %s", device.address_str_to(addr_buf));
+    if (address_matches) {
+      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      ESP_LOGE(TAG, "Encrypted BTHome frame received but no bindkey configured for %s",
+               device.address_str_to(addr_buf));
+    }
     return false;
   }
 
   if (!is_encrypted && this->has_bindkey_) {
-    char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-    ESP_LOGE(TAG, "Unencrypted BTHome frame received with bindkey configured for %s", device.address_str_to(addr_buf));
+    if (address_matches) {
+      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      ESP_LOGE(TAG, "Unencrypted BTHome frame received with bindkey configured for %s",
+               device.address_str_to(addr_buf));
+    }
     return false;
   }
-
-  uint64_t source_address = device.address_uint64();
   std::vector<uint8_t> decrypted_payload;
   const uint8_t *payload = nullptr;
   size_t payload_size = 0;

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -237,13 +237,13 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
 
   if (is_encrypted && !this->has_bindkey_) {
     char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-    ESP_LOGV(TAG, "Ignoring encrypted BTHome frame without bindkey from %s", device.address_str_to(addr_buf));
+    ESP_LOGE(TAG, "Encrypted BTHome frame received but no bindkey configured for %s", device.address_str_to(addr_buf));
     return false;
   }
 
   if (!is_encrypted && this->has_bindkey_) {
     char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-    ESP_LOGV(TAG, "Ignoring unencrypted BTHome frame for bindkey device %s", device.address_str_to(addr_buf));
+    ESP_LOGE(TAG, "Unencrypted BTHome frame received with bindkey configured for %s", device.address_str_to(addr_buf));
     return false;
   }
 

--- a/esphome/components/bthome_mithermometer/bthome_ble.h
+++ b/esphome/components/bthome_mithermometer/bthome_ble.h
@@ -5,6 +5,7 @@
 #include "esphome/core/component.h"
 
 #include <cstdint>
+#include <vector>
 
 #ifdef USE_ESP32
 
@@ -14,6 +15,7 @@ namespace bthome_mithermometer {
 class BTHomeMiThermometer : public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   void set_address(uint64_t address) { this->address_ = address; }
+  void set_bindkey(const char *bindkey);
 
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { this->humidity_ = humidity; }
@@ -27,9 +29,13 @@ class BTHomeMiThermometer : public esp32_ble_tracker::ESPBTDeviceListener, publi
  protected:
   bool handle_service_data_(const esp32_ble_tracker::ServiceData &service_data,
                             const esp32_ble_tracker::ESPBTDevice &device);
+  bool decrypt_bthome_payload_(const std::vector<uint8_t> &data, uint64_t source_address,
+                               std::vector<uint8_t> &payload) const;
 
   uint64_t address_{0};
   optional<uint8_t> last_packet_id_{};
+  bool has_bindkey_{false};
+  uint8_t bindkey_[16];
 
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};


### PR DESCRIPTION
### Motivation
- Support BTHome v2 encrypted beacons (AES-CCM) emitted by firmware like pvvx/ATC_MiThermometer and allow users to provide the pre-shared key (`miBindKey`) in configuration.
- Ensure that when a `bindkey` is configured for a device, only encrypted frames for that MAC are accepted to avoid processing unencrypted/mixed data.

### Description
- Added an optional `bindkey` configuration option (`cv.bind_key`) to the component schema and wired it into setup with `set_bindkey` in `__init__.py`.
- Added `set_bindkey`, `bindkey_` storage and `has_bindkey_` flag to the component interface in `bthome_ble.h` and log the bindkey in `dump_config`.
- Implemented `decrypt_bthome_payload_` in `bthome_ble.cpp` which builds the BTHome v2 nonce (MAC + UUID + device byte + counter) and performs AES-CCM authenticated decryption with `mbedtls_ccm_auth_decrypt`, replacing the encrypted payload with the decrypted payload for normal parsing.
- Integrated decryption into payload handling and parsing, adjusted MAC-included handling to operate on decrypted payload, and enforced policy to ignore encrypted frames without a configured bindkey and to ignore unencrypted frames when a bindkey is configured.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697116bf7f00832786cc9fbb2b05fb2f)