### PR TITLE
Move BTHome bindkey parsing to Python

### DIFF
--- a/esphome/components/bthome_mithermometer/__init__.py
+++ b/esphome/components/bthome_mithermometer/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import esp32_ble_tracker
 import esphome.config_validation as cv
 from esphome.const import CONF_BINDKEY, CONF_ID, CONF_MAC_ADDRESS
+from esphome.core import HexInt
 
 CODEOWNERS = ["@nagyrobi"]
 DEPENDENCIES = ["esp32_ble_tracker"]
@@ -35,7 +36,9 @@ async def setup_bthome_mithermometer(var, config):
     await cg.register_component(var, config)
     await esp32_ble_tracker.register_ble_device(var, config)
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
-    if CONF_BINDKEY in config:
     if bindkey := config.get(CONF_BINDKEY):
-        # Parse the hex here and create an array of bytes
-        cg.add(var.set_bindkey(bindkey_initialiser)
+        bindkey_bytes = [
+            HexInt(int(bindkey[index : index + 2], 16))
+            for index in range(0, len(bindkey), 2)
+        ]
+        cg.add(var.set_bindkey(cg.ArrayInitializer(*bindkey_bytes)))

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <span>
@@ -161,8 +162,12 @@ bool BTHomeMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &dev
   return matched;
 }
 
-void BTHomeMiThermometer::set_bindkey(const char *bindkey) {
-  parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_));
+void BTHomeMiThermometer::set_bindkey(std::initializer_list<uint8_t> bindkey) {
+  if (bindkey.size() != sizeof(this->bindkey_)) {
+    ESP_LOGW(TAG, "BTHome bindkey size mismatch: %zu", bindkey.size());
+    return;
+  }
+  std::copy(bindkey.begin(), bindkey.end(), this->bindkey_);
   this->has_bindkey_ = true;
 }
 

--- a/esphome/components/bthome_mithermometer/bthome_ble.h
+++ b/esphome/components/bthome_mithermometer/bthome_ble.h
@@ -5,6 +5,7 @@
 #include "esphome/core/component.h"
 
 #include <cstdint>
+#include <initializer_list>
 #include <vector>
 
 #ifdef USE_ESP32
@@ -15,7 +16,7 @@ namespace bthome_mithermometer {
 class BTHomeMiThermometer : public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   void set_address(uint64_t address) { this->address_ = address; }
-  void set_bindkey(const char *bindkey);
+  void set_bindkey(std::initializer_list<uint8_t> bindkey);
 
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { this->humidity_ = humidity; }


### PR DESCRIPTION
### Motivation
- Move bindkey parsing out of the C++ runtime so the Python code generates a byte initializer at codegen time and the C++ code only consumes the parsed bytes.

### Description
- Parse `CONF_BINDKEY` in `esphome/components/bthome_mithermometer/__init__.py` into a list of byte values and pass them to C++ with `cg.ArrayInitializer(*bindkey_bytes)`.
- Change the C++ API in `bthome_ble.h` from `void set_bindkey(const char *bindkey)` to `void set_bindkey(std::initializer_list<uint8_t> bindkey)` and add the required `<initializer_list>` include.
- Update `bthome_ble.cpp` to implement `set_bindkey(std::initializer_list<uint8_t>)`, validate the initializer size, log a warning on mismatch with `ESP_LOGW`, and copy the bytes into `bindkey_`, and add the `<algorithm>` include.
- All other parsing/decryption logic is unchanged; the C++ code no longer calls `parse_hex` for bindkeys.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971edc0910c8327a5a5ecd467cd88c4)