### PR TITLE
Implement buffered ESPHome cspot audio sink with speaker/audio_dac support

### DIFF
--- a/esphome/components/cspot/__init__.py
+++ b/esphome/components/cspot/__init__.py
@@ -1,0 +1,32 @@
+import esphome.codegen as cg
+from esphome.components import audio_dac, speaker
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@esphome/core"]
+DEPENDENCIES = ["network"]
+
+CONF_SINK = "sink"
+
+cspot_ns = cg.esphome_ns.namespace("cspot")
+CSpotComponent = cspot_ns.class_("CSpotComponent", cg.Component)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(CSpotComponent),
+        cv.Required(CONF_SINK): cv.Any(
+            cv.use_id(speaker.Speaker),
+            cv.use_id(audio_dac.AudioDac),
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    sink = await cg.get_variable(config[CONF_SINK])
+    cg.add(var.set_sink(sink))
+
+    cg.add_library("cspot", None, "https://github.com/philippe44/cspot.git")

--- a/esphome/components/cspot/cspot.cpp
+++ b/esphome/components/cspot/cspot.cpp
@@ -1,0 +1,116 @@
+#include "cspot.h"
+
+namespace esphome {
+namespace cspot {
+
+static const char *const TAG = "cspot";
+
+ESPHomeAudioSink::ESPHomeAudioSink(speaker::Speaker *speaker, audio_dac::AudioDac *audio_dac)
+    : speaker_(speaker), audio_dac_(audio_dac) {
+  this->softwareVolumeControl = audio_dac == nullptr;
+}
+
+void ESPHomeAudioSink::feedPCMFrames(std::vector<uint8_t> &data) { this->feedPCMFrames(data.data(), data.size()); }
+
+void ESPHomeAudioSink::feedPCMFrames(const uint8_t *data, size_t length) {
+  if (data == nullptr || length == 0 || this->speaker_ == nullptr) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(this->mutex_);
+
+  while (this->queue_.size() + length > CSPOT_MAX_BUFFER_SIZE && !this->queue_.empty()) {
+    this->queue_.pop_front();
+  }
+
+  this->queue_.insert(this->queue_.end(), data, data + length);
+}
+
+void ESPHomeAudioSink::volumeChanged(uint16_t volume) {
+  const float normalized = clamp(static_cast<float>(volume) / 0xFFFF, 0.0f, 1.0f);
+
+  if (this->audio_dac_ != nullptr) {
+    this->audio_dac_->set_volume(normalized);
+  }
+
+  if (this->speaker_ != nullptr) {
+    this->speaker_->set_volume(normalized);
+  }
+}
+
+void ESPHomeAudioSink::loop() {
+  if (this->speaker_ == nullptr) {
+    return;
+  }
+
+  std::vector<uint8_t> out;
+  {
+    std::lock_guard<std::mutex> lock(this->mutex_);
+    const size_t to_write = std::min<size_t>(this->queue_.size(), CSPOT_WRITE_CHUNK_SIZE);
+
+    if (to_write == 0) {
+      return;
+    }
+
+    out.reserve(to_write);
+    for (size_t i = 0; i < to_write; i++) {
+      out.push_back(this->queue_.front());
+      this->queue_.pop_front();
+    }
+  }
+
+  if (!this->started_) {
+    this->speaker_->start();
+    this->started_ = true;
+  }
+
+  const size_t written = this->speaker_->play(out.data(), out.size());
+  if (written < out.size()) {
+    std::lock_guard<std::mutex> lock(this->mutex_);
+    this->queue_.insert(this->queue_.begin(), out.begin() + written, out.end());
+  }
+}
+
+void ESPHomeAudioSink::stop() {
+  if (this->speaker_ != nullptr && this->started_) {
+    this->speaker_->stop();
+  }
+  this->started_ = false;
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  this->queue_.clear();
+}
+
+size_t ESPHomeAudioSink::buffered() const {
+  std::lock_guard<std::mutex> lock(this->mutex_);
+  return this->queue_.size();
+}
+
+void CSpotComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up cspot...");
+
+  if (this->speaker_sink_ == nullptr) {
+    ESP_LOGE(TAG, "A speaker sink is required for cspot playback.");
+    this->mark_failed();
+    return;
+  }
+
+  this->speaker_sink_->set_audio_stream_info(audio::AudioStreamInfo(44100, 2, 16));
+  this->sink_impl_ = std::make_unique<ESPHomeAudioSink>(this->speaker_sink_, this->audio_dac_sink_);
+}
+
+void CSpotComponent::loop() {
+  if (this->sink_impl_ != nullptr) {
+    this->sink_impl_->loop();
+  }
+}
+
+void CSpotComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "cspot:");
+  LOG_COMPONENT("  ", "", this);
+
+  ESP_LOGCONFIG(TAG, "  Sink type: %s", this->speaker_sink_ != nullptr ? "speaker" : "audio_dac");
+  ESP_LOGCONFIG(TAG, "  Buffer: %u bytes", static_cast<unsigned int>(this->sink_impl_ != nullptr ? this->sink_impl_->buffered() : 0));
+}
+
+}  // namespace cspot
+}  // namespace esphome

--- a/esphome/components/cspot/cspot.h
+++ b/esphome/components/cspot/cspot.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/components/audio_dac/audio_dac.h"
+#include "esphome/components/speaker/speaker.h"
+
+#include "AudioSink.h"
+
+namespace esphome {
+namespace cspot {
+
+static constexpr size_t CSPOT_MAX_BUFFER_SIZE = 64 * 1024;
+static constexpr size_t CSPOT_WRITE_CHUNK_SIZE = 4 * 1024;
+
+class ESPHomeAudioSink : public ::AudioSink {
+ public:
+  explicit ESPHomeAudioSink(speaker::Speaker *speaker, audio_dac::AudioDac *audio_dac = nullptr);
+
+  void feedPCMFrames(std::vector<uint8_t> &data);
+  void feedPCMFrames(const uint8_t *data, size_t length);
+  void volumeChanged(uint16_t volume);
+
+  void loop();
+  void stop();
+  size_t buffered() const;
+
+ protected:
+  speaker::Speaker *speaker_;
+  audio_dac::AudioDac *audio_dac_;
+
+  mutable std::mutex mutex_;
+  std::deque<uint8_t> queue_;
+  bool started_{false};
+};
+
+class CSpotComponent : public Component {
+ public:
+  void set_sink(speaker::Speaker *sink) { this->speaker_sink_ = sink; }
+  void set_sink(audio_dac::AudioDac *sink) { this->audio_dac_sink_ = sink; }
+
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+ protected:
+  speaker::Speaker *speaker_sink_{nullptr};
+  audio_dac::AudioDac *audio_dac_sink_{nullptr};
+
+  std::unique_ptr<ESPHomeAudioSink> sink_impl_;
+};
+
+}  // namespace cspot
+}  // namespace esphome


### PR DESCRIPTION
### Motivation
- Replace the previous no-op C++ scaffold with a real audio sink so cspot can output playable PCM audio on ESPHome devices.
- Reduce choppy playback by buffering incoming PCM frames and draining them at a controlled chunk size.
- Support hardware volume control when an `audio_dac` is present and let cspot disable its software volume control in that case.

### Description
- Add `ESPHomeAudioSink` in `cspot.h`/`cspot.cpp` that implements `feedPCMFrames(std::vector<uint8_t>&)` plus a pointer/length overload, internal buffering (thread-safe `std::deque<uint8_t>`), and `buffered()`/`stop()`/`loop()` utilities.
- Introduce buffer size constants `CSPOT_MAX_BUFFER_SIZE` and `CSPOT_WRITE_CHUNK_SIZE` and implement overflow handling that drops oldest data when the buffer would overflow.
- Implement `volumeChanged(uint16_t)` to map Spotify volume to ESPHome `speaker` and optional `audio_dac` via `set_volume(...)`, and set `softwareVolumeControl` based on whether an `audio_dac` was provided in the constructor.
- Wire `CSpotComponent::setup()` to configure `44100 Hz, stereo, 16-bit` via `set_audio_stream_info(...)`, instantiate the `ESPHomeAudioSink`, and drain audio regularly from `loop()`; `dump_config()` now logs sink type and buffer usage.
- Keep the Python codegen schema and `cg.add_library("cspot", ...)` registration so the component remains configurable via the `sink:` option accepting `speaker` or `audio_dac`.

### Testing
- Ran `python -m compileall esphome/components/cspot` and the compilation step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db44e376c83279c6341dad436d5ed)